### PR TITLE
Fix day color bars: discrete per-hour stripes on the full ramp

### DIFF
--- a/public/js/core/evaluate.js
+++ b/public/js/core/evaluate.js
@@ -6,9 +6,6 @@ import { categoryFromWmoCode, describeWmoCode } from "./wmo.js";
 // worst of its metric statuses, per the spec: one red makes the hour red.
 export const STATUS_ORDER = { good: 0, marginal: 1, bad: 2 };
 
-// Ramp positions for the continuous score: good 0, marginal 0.5, bad 1.
-export const STATUS_SCORE = { good: 0, marginal: 0.5, bad: 1 };
-
 function worst(statuses) {
   return statuses.reduce(
     (acc, s) => (STATUS_ORDER[s] > STATUS_ORDER[acc] ? s : acc),
@@ -91,10 +88,11 @@ function evalSwell(hour, prefs) {
 
 // hour: merged hourly record from core/forecast.js.
 // Returns { metrics: { wind, temp, conditions, tide?, swell? }, overall,
-// score }. `overall` is the worst metric status. `score` is the mean ramp
-// position of all metrics regardless of how many there are: all good is 0
-// (green), half good is 0.5 (yellow), a quarter good is 0.75 (between
-// yellow and red), none good is 1 (red). Marginal counts as half a good.
+// score }. `overall` is the worst metric status. `score` is the hour's
+// ramp position: any bad metric pins it to 1 (full red); otherwise the
+// fraction of good metrics sets the spot on the full ramp regardless of
+// how many metrics there are. All good is 0 (green), half good is 0.5
+// (yellow), a quarter good is 0.75 (between yellow and red).
 export function evaluateHour(hour, prefs) {
   const metrics = {
     wind: evalWind(hour, prefs),
@@ -105,7 +103,8 @@ export function evaluateHour(hour, prefs) {
   if (prefs.swell.enabled) metrics.swell = evalSwell(hour, prefs);
   const statuses = Object.values(metrics).map((m) => m.status);
   const overall = worst(statuses);
+  const goodCount = statuses.filter((s) => s === "good").length;
   const score =
-    statuses.reduce((sum, s) => sum + STATUS_SCORE[s], 0) / statuses.length;
+    overall === "bad" ? 1 : 1 - goodCount / statuses.length;
   return { metrics, overall, score };
 }

--- a/public/js/core/evaluate.js
+++ b/public/js/core/evaluate.js
@@ -91,10 +91,10 @@ function evalSwell(hour, prefs) {
 
 // hour: merged hourly record from core/forecast.js.
 // Returns { metrics: { wind, temp, conditions, tide?, swell? }, overall,
-// score }. `overall` is the worst metric status. Any bad metric pins the
-// hour's score to 1 (full red). Otherwise the score is the mean ramp
-// position of the good/marginal metrics, so two goods and two marginals
-// land exactly halfway between green and yellow.
+// score }. `overall` is the worst metric status. `score` is the mean ramp
+// position of all metrics regardless of how many there are: all good is 0
+// (green), half good is 0.5 (yellow), a quarter good is 0.75 (between
+// yellow and red), none good is 1 (red). Marginal counts as half a good.
 export function evaluateHour(hour, prefs) {
   const metrics = {
     wind: evalWind(hour, prefs),
@@ -105,8 +105,7 @@ export function evaluateHour(hour, prefs) {
   if (prefs.swell.enabled) metrics.swell = evalSwell(hour, prefs);
   const statuses = Object.values(metrics).map((m) => m.status);
   const overall = worst(statuses);
-  const score = overall === "bad"
-    ? 1
-    : statuses.reduce((sum, s) => sum + STATUS_SCORE[s], 0) / statuses.length;
+  const score =
+    statuses.reduce((sum, s) => sum + STATUS_SCORE[s], 0) / statuses.length;
   return { metrics, overall, score };
 }

--- a/public/js/core/evaluate.js
+++ b/public/js/core/evaluate.js
@@ -91,10 +91,10 @@ function evalSwell(hour, prefs) {
 
 // hour: merged hourly record from core/forecast.js.
 // Returns { metrics: { wind, temp, conditions, tide?, swell? }, overall,
-// score }. `overall` is the worst metric status (one red flags the
-// hour). `score` is the mean ramp position of the metrics, so an hour
-// with two goods and a marginal scores between good and marginal and
-// can be shaded proportionally on the color ramp.
+// score }. `overall` is the worst metric status. Any bad metric pins the
+// hour's score to 1 (full red). Otherwise the score is the mean ramp
+// position of the good/marginal metrics, so two goods and two marginals
+// land exactly halfway between green and yellow.
 export function evaluateHour(hour, prefs) {
   const metrics = {
     wind: evalWind(hour, prefs),
@@ -105,7 +105,8 @@ export function evaluateHour(hour, prefs) {
   if (prefs.swell.enabled) metrics.swell = evalSwell(hour, prefs);
   const statuses = Object.values(metrics).map((m) => m.status);
   const overall = worst(statuses);
-  const score =
-    statuses.reduce((sum, s) => sum + STATUS_SCORE[s], 0) / statuses.length;
+  const score = overall === "bad"
+    ? 1
+    : statuses.reduce((sum, s) => sum + STATUS_SCORE[s], 0) / statuses.length;
   return { metrics, overall, score };
 }

--- a/public/js/ui/views.js
+++ b/public/js/ui/views.js
@@ -137,9 +137,10 @@ export function renderDayView(forecast, dayIndex, { onPickDay }) {
 // ---- week summary ----
 
 // A day's color signature: one solid stripe per hour, no blending between
-// hours. Each stripe sits on the full good-to-bad ramp by the hour's mix
-// of metric statuses: all good is the good color, half good is exactly
-// the marginal color, a quarter good sits between marginal and bad.
+// hours. An hour with any bad metric is the full bad color; otherwise the
+// fraction of good metrics picks the spot on the full ramp (all good is
+// the good color, half good exactly the marginal color, a quarter good
+// between marginal and bad).
 function dayColorBar(day, scheme) {
   const bar = el("span", "day-bar");
   const n = day.hours.length;

--- a/public/js/ui/views.js
+++ b/public/js/ui/views.js
@@ -136,10 +136,10 @@ export function renderDayView(forecast, dayIndex, { onPickDay }) {
 
 // ---- week summary ----
 
-// A day's color signature. Each hour's mean metric score picks a shade
-// along the good-marginal-bad ramp (GIS style: all good is exactly the
-// good color, two goods and a marginal a shade toward yellow), and the
-// shades blend smoothly across the day.
+// A day's color signature: one solid stripe per hour, no blending between
+// hours. An hour with any bad metric is the full bad color; otherwise its
+// good/marginal mix picks the shade (two goods and two marginals sit
+// exactly halfway between green and yellow).
 function dayColorBar(day, scheme) {
   const bar = el("span", "day-bar");
   const n = day.hours.length;
@@ -149,7 +149,9 @@ function dayColorBar(day, scheme) {
     bar.style.background = colors[0];
     return bar;
   }
-  const stops = colors.map((c, i) => `${c} ${((i + 0.5) / n) * 100}%`);
+  const stops = colors.map(
+    (c, i) => `${c} ${(i / n) * 100}%, ${c} ${((i + 1) / n) * 100}%`
+  );
   bar.style.background = `linear-gradient(to right, ${stops.join(", ")})`;
   return bar;
 }

--- a/public/js/ui/views.js
+++ b/public/js/ui/views.js
@@ -137,9 +137,9 @@ export function renderDayView(forecast, dayIndex, { onPickDay }) {
 // ---- week summary ----
 
 // A day's color signature: one solid stripe per hour, no blending between
-// hours. An hour with any bad metric is the full bad color; otherwise its
-// good/marginal mix picks the shade (two goods and two marginals sit
-// exactly halfway between green and yellow).
+// hours. Each stripe sits on the full good-to-bad ramp by the hour's mix
+// of metric statuses: all good is the good color, half good is exactly
+// the marginal color, a quarter good sits between marginal and bad.
 function dayColorBar(day, scheme) {
   const bar = el("span", "day-bar");
   const n = day.hours.length;


### PR DESCRIPTION
## What changed

Reworks how the week/day color bars are computed and drawn so each hour reads as a discrete category rather than a smooth gradient.

- **Solid per-hour stripes.** `dayColorBar` in `public/js/ui/views.js` now emits hard-edged gradient stops (`color i/n%, color (i+1)/n%`) so each hour is one solid block with no blending between adjacent hours.
- **Full red→yellow→green ramp by status mix.** `evaluateHour` in `public/js/core/evaluate.js` now computes an hour's `score` from the fraction of *good* metrics: all good is green, half good is exactly yellow, a quarter good sits between yellow and red. This replaces the old mean that only spanned green→yellow and dropped the red half of the ramp.
- **Any red pins the hour to full red.** If any single metric is bad, the hour's stripe is the full bad color regardless of the other metrics, matching the "one red makes the hour red" rule.

## Why

The previous bars used a continuous gradient that blended across hours and only ever ramped between green and yellow, so a mostly-bad hour never looked red and individual hours were hard to read. The new approach gives a clean per-hour "go / maybe / nope" signal.

## Notes for reviewers

- The scoring is a fraction of total metrics, so it scales automatically when the number of attributes changes (e.g. toggling tide or swell on/off in preferences).
- Both color schemes go through the same `SCHEMES` table, so the colorblind (blue→red) palette gets identical treatment with blue substituted for green.
- Consequence of the literal rule: an hour where every metric is *marginal* (zero good) lands at the red end of the ramp and renders fully red, indistinguishable from an hour with an actual bad metric. Flagging in case you'd prefer marginals to count as half a good instead.
- Verified live in the wrangler preview: hours with 2 of 4 good render exactly the marginal color `#e2b93b`, and 1 of 4 good renders `rgb(221,130,59)`, the midpoint between yellow and red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)