### PR TITLE
Rate swell steepness by period-to-height ratio; fix shadowed wind defaults

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -62,12 +62,6 @@
       "lat": 35.3295,
       "lon": -120.84422,
       "prefs": {
-        "wind": {
-          "excellentMax": 1,
-          "acceptableMax": 2,
-          "marginalMax": 3,
-          "protectedMax": 4
-        },
         "tide": {
           "enabled": true,
           "stationId": "9412110"
@@ -80,12 +74,6 @@
       "lat": 35.3721,
       "lon": -120.86019,
       "prefs": {
-        "wind": {
-          "excellentMax": 1,
-          "acceptableMax": 2,
-          "marginalMax": 3,
-          "protectedMax": 4
-        },
         "tide": {
           "stationId": "9412110",
           "minFt": 0
@@ -98,12 +86,6 @@
       "lat": 35.17768,
       "lon": -120.74859,
       "prefs": {
-        "wind": {
-          "excellentMax": 1,
-          "acceptableMax": 2,
-          "marginalMax": 3,
-          "protectedMax": 4
-        },
         "waves": {
           "enabled": true,
           "protectedSectors": [
@@ -128,12 +110,6 @@
       "lat": 35.64038,
       "lon": -121.19392,
       "prefs": {
-        "wind": {
-          "excellentMax": 1,
-          "acceptableMax": 2,
-          "marginalMax": 3,
-          "protectedMax": 4
-        },
         "waves": {
           "enabled": true,
           "protectedSectors": [
@@ -159,12 +135,6 @@
       "lat": 35.58116,
       "lon": -121.11934,
       "prefs": {
-        "wind": {
-          "excellentMax": 1,
-          "acceptableMax": 2,
-          "marginalMax": 3,
-          "protectedMax": 4
-        },
         "temp": {
           "excellentMin": 65,
           "excellentMax": 75
@@ -184,12 +154,6 @@
       "lat": 35.27421,
       "lon": -120.8883,
       "prefs": {
-        "wind": {
-          "excellentMax": 1,
-          "acceptableMax": 2,
-          "marginalMax": 3,
-          "protectedMax": 4
-        },
         "waves": {
           "enabled": true,
           "protectedSectors": [

--- a/public/config.json
+++ b/public/config.json
@@ -50,9 +50,7 @@
       "excellentMaxFt": 2,
       "acceptableMaxFt": 3,
       "marginalMaxFt": 4,
-      "minPeriodS": 8,
-      "protectedSectors": [],
-      "protectedMaxFt": 6
+      "periodRatio": 2
     }
   },
   "locations": [
@@ -87,20 +85,7 @@
       "lon": -120.74859,
       "prefs": {
         "waves": {
-          "enabled": true,
-          "protectedSectors": [
-            0,
-            1,
-            2,
-            3,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15
-          ]
+          "enabled": true
         }
       }
     },
@@ -111,21 +96,7 @@
       "lon": -121.19392,
       "prefs": {
         "waves": {
-          "enabled": true,
-          "protectedSectors": [
-            0,
-            1,
-            2,
-            3,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15
-          ]
+          "enabled": true
         }
       }
     },
@@ -155,20 +126,7 @@
       "lon": -120.8883,
       "prefs": {
         "waves": {
-          "enabled": true,
-          "protectedSectors": [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11
-          ]
+          "enabled": true
         }
       }
     }

--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,5 @@
 {
-  "version": 8,
+  "version": 9,
   "colors": {
     "green-red": [
       "#15803D",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -380,7 +380,7 @@ function route() {
 // The version baked into this file. config.json carries the matching
 // deploy stamp and is always fetched with no-cache, so a client running
 // old cached JS sees a newer number there and reloads itself once.
-const APP_VERSION = 8;
+const APP_VERSION = 9;
 
 function reloadIfStaleBuild() {
   const deployed = getConfigVersion();

--- a/public/js/core/evaluate.js
+++ b/public/js/core/evaluate.js
@@ -90,40 +90,58 @@ function evalTide(hour, prefs) {
   return { category, value: `${hour.tideFt.toFixed(1)} ft`, detail: "MLLW" };
 }
 
-// Rates the total sea state: waveFt is significant wave height with
-// swell and wind waves combined, per the observation study (a small
-// swell plus wind chop can still be a no-go). The minimum period only
-// gates the excellent tier; short-period water at excellent height
-// paddles like merely acceptable water, not dangerous water.
+// Rates the total sea state. Height tiers use waveFt, significant wave
+// height with swell and wind waves combined, per the observation study
+// (a small swell plus wind chop can still be a no-go).
+//
+// On top of the height tier sits a steepness rule from the ocean-kayak
+// rule of thumb: swell is comfortable when its period in seconds is at
+// least periodRatio times its height in feet (2x by default). A fixed
+// period floor gets this wrong because 8 seconds rides fine under a
+// 2 ft swell and genuinely rough under a 4 ft one. Failing the ratio
+// demotes the hour one tier; failing it badly (under 3/4 of the ratio)
+// also caps the hour at marginal, since steep short-period water is
+// unpleasant at any height. The check uses the swell component's own
+// height and period, not the blended totals, because wind chop drags
+// the blended period down and the chop itself is already priced into
+// the height tier and the wind metric.
 function evalWaves(hour, prefs) {
   if (hour.waveFt == null) {
     return { category: "marginal", value: "no data", detail: "" };
   }
   const p = prefs.waves;
   const sector = sectorFromDegrees(hour.waveDirDeg ?? 0);
-  const isProtected = p.protectedSectors.includes(sector);
-  const marginalLimit = isProtected
-    ? Math.max(p.marginalMaxFt, p.protectedMaxFt)
-    : p.marginalMaxFt;
-  const periodOk =
-    hour.wavePeriodS == null || hour.wavePeriodS >= p.minPeriodS;
-  let category;
-  if (hour.waveFt > marginalLimit) category = "notForMe";
-  else if (hour.waveFt <= p.excellentMaxFt && periodOk) category = "excellent";
-  else if (hour.waveFt <= p.acceptableMaxFt) category = "acceptable";
-  else category = "marginal";
+  let tier;
+  if (hour.waveFt <= p.excellentMaxFt) tier = 0;
+  else if (hour.waveFt <= p.acceptableMaxFt) tier = 1;
+  else if (hour.waveFt <= p.marginalMaxFt) tier = 2;
+  else tier = 3;
+  let steepness = "";
+  if (hour.swellFt > 0 && hour.swellPeriodS != null) {
+    const needS = p.periodRatio * hour.swellFt;
+    if (hour.swellPeriodS < needS * 0.75) {
+      tier = Math.max(tier + 1, 2);
+      steepness = "very steep swell";
+    } else if (hour.swellPeriodS < needS) {
+      tier += 1;
+      steepness = "steep swell";
+    }
+  }
+  const category = ["excellent", "acceptable", "marginal", "notForMe"][
+    Math.min(tier, 3)
+  ];
   // Components are shown for context, not as a sum: wave heights
   // combine non-linearly and the total also includes secondary swell
   // trains Open-Meteo does not break out.
   const details = [];
   if (hour.swellFt != null && hour.windWaveFt != null) {
+    const swellPeriod =
+      hour.swellPeriodS != null ? ` @ ${Math.round(hour.swellPeriodS)}s` : "";
     details.push(
-      `primary swell ${hour.swellFt.toFixed(1)} ft, wind chop ${hour.windWaveFt.toFixed(1)} ft`
+      `swell ${hour.swellFt.toFixed(1)} ft${swellPeriod}, wind chop ${hour.windWaveFt.toFixed(1)} ft`
     );
   }
-  if (isProtected && hour.waveFt > p.marginalMaxFt) {
-    details.push("allowed by protected direction");
-  }
+  if (steepness) details.push(steepness);
   return {
     category,
     value: `${hour.waveFt.toFixed(1)} ft @ ${

--- a/public/js/core/forecast.js
+++ b/public/js/core/forecast.js
@@ -90,6 +90,7 @@ export async function buildForecast(location, options = {}) {
         wavePeriodS: marine.get(record.iso)?.wavePeriodS ?? null,
         waveDirDeg: marine.get(record.iso)?.waveDirDeg ?? null,
         swellFt: marine.get(record.iso)?.swellFt ?? null,
+        swellPeriodS: marine.get(record.iso)?.swellPeriodS ?? null,
         windWaveFt: marine.get(record.iso)?.windWaveFt ?? null,
       };
       // Tag the hour that contains sunrise or sunset with the event and

--- a/public/js/core/prefs.js
+++ b/public/js/core/prefs.js
@@ -2,8 +2,9 @@
 //
 // Direction preferences use 16 compass sectors, index 0 = N through
 // 15 = NNW, each spanning 22.5 degrees. "Protected" sectors model
-// terrain shielding: when wind or waves arrive from a protected
-// sector, the tolerated upper limit is extended.
+// terrain shielding: when wind arrives from a protected sector, the
+// tolerated upper limit is extended. Only wind uses them; swell
+// shielding is a launch concern, not an on-the-water one.
 //
 // Every metric rates into four categories: excellent, acceptable,
 // marginal, notForMe. Wind, temperature, and waves use nested
@@ -68,15 +69,15 @@ function builtinPrefs() {
       marginFt: 0.5,
     },
     waves: {
-      // Total significant wave height, swell and wind waves combined.
-      // The minimum period gates the excellent tier only.
+      // Height tiers rate total significant wave height, swell and wind
+      // waves combined. periodRatio is the steepness rule: swell rides
+      // comfortably when its period (s) is at least this multiple of
+      // its height (ft). See evalWaves in evaluate.js.
       enabled: false,
       excellentMaxFt: 2,
       acceptableMaxFt: 3,
       marginalMaxFt: 4,
-      minPeriodS: 8,
-      protectedSectors: [],
-      protectedMaxFt: 6,
+      periodRatio: 2,
     },
   };
 }
@@ -152,10 +153,16 @@ function migrateStored(stored) {
       excellentMaxFt: w.goodMaxFt,
       acceptableMaxFt: (w.goodMaxFt + w.maxFt) / 2,
       marginalMaxFt: w.maxFt,
-      minPeriodS: w.minPeriodS ?? 8,
-      protectedSectors: w.protectedSectors ?? [],
-      protectedMaxFt: w.protectedMaxFt ?? w.maxFt + 2,
     };
+  }
+  // The wave rule used a fixed minimum period and direction shielding
+  // before the steepness ratio replaced them. Terrain shielding from
+  // swell is a launch concern, not an on-the-water one, so those keys
+  // just drop; the ratio comes in from defaults.
+  if (out.waves) {
+    const { minPeriodS, protectedSectors, protectedMaxFt, ...rest } =
+      out.waves;
+    out.waves = rest;
   }
   return out;
 }

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -17,8 +17,8 @@ const editor = document.getElementById("editor");
 // key) still gives every control something to bind to.
 const SHAPE = {
   wind: {
-    excellentMax: 1, acceptableMax: 2, marginalMax: 3,
-    protectedSectors: [], protectedMax: 4,
+    excellentMax: 0, acceptableMax: 1, marginalMax: 2,
+    protectedSectors: [], protectedMax: 3,
   },
   temp: {
     excellentMin: 65, excellentMax: 75,
@@ -33,7 +33,7 @@ const SHAPE = {
   tide: { enabled: false, stationId: "", minFt: 2.5, marginFt: 0.5 },
   waves: {
     enabled: false, excellentMaxFt: 2, acceptableMaxFt: 3, marginalMaxFt: 4,
-    minPeriodS: 8, protectedSectors: [], protectedMaxFt: 6,
+    periodRatio: 2,
   },
 };
 

--- a/public/js/providers/openmeteo.js
+++ b/public/js/providers/openmeteo.js
@@ -59,15 +59,20 @@ export async function fetchWeather(lat, lon, days = 7) {
 }
 
 // Returns Map<localIso, { waveFt, wavePeriodS, waveDirDeg, swellFt,
-// windWaveFt }>. waveFt is the total significant wave height, swell and
-// wind waves combined, which is what the paddler actually feels. The
-// swell and wind-wave components ride along for display.
+// swellPeriodS, windWaveFt }>. waveFt is the total significant wave
+// height, swell and wind waves combined, which is what the paddler
+// actually feels. The swell component carries its own period because
+// the blended wave_period mixes in short wind chop and understates how
+// the swell itself rides; the steepness rule in core/evaluate.js needs
+// the swell's own numbers.
 // Throws if the point has no marine coverage (e.g. inland).
 export async function fetchMarine(lat, lon, days = 7) {
   const params = new URLSearchParams({
     latitude: lat.toFixed(4),
     longitude: lon.toFixed(4),
-    hourly: "wave_height,wave_period,wave_direction,swell_wave_height,wind_wave_height",
+    hourly:
+      "wave_height,wave_period,wave_direction," +
+      "swell_wave_height,swell_wave_period,wind_wave_height",
     length_unit: "imperial",
     forecast_days: String(days),
     timezone: TIMEZONE,
@@ -81,6 +86,7 @@ export async function fetchMarine(lat, lon, days = 7) {
       wavePeriodS: h.wave_period[i],
       waveDirDeg: h.wave_direction[i],
       swellFt: h.swell_wave_height[i],
+      swellPeriodS: h.swell_wave_period[i],
       windWaveFt: h.wind_wave_height[i],
     });
   }

--- a/public/js/ui/prefsform.js
+++ b/public/js/ui/prefsform.js
@@ -5,7 +5,7 @@
 // buildPrefsForm(prefs) returns { element, read }. `element` is a
 // fragment of settings sections to drop into a form; `read()` returns a
 // full prefs object reflecting the current control values, including
-// the protected-direction wheels for wind and waves.
+// the protected-direction wheel for wind.
 
 import { BEAUFORT, beaufortMphRange } from "../core/beaufort.js";
 import { CONDITION_CATEGORIES } from "../core/wmo.js";
@@ -182,7 +182,7 @@ export function buildPrefsForm(prefs) {
   // Waves
   const waves = section(
     "Waves",
-    "For open-coast launches. Total wave height, swell and wind waves combined, with nested ceilings like wind. The minimum period only applies to the excellent tier. Protected directions allow bigger waves."
+    "For open-coast launches. Total wave height, swell and wind waves combined, with nested ceilings like wind. Steepness demotes an hour when the swell period (seconds) is less than the ratio times the swell height (feet); period at least twice the height rides flat."
   );
   const wavesEnabled = el("input");
   wavesEnabled.type = "checkbox";
@@ -190,19 +190,15 @@ export function buildPrefsForm(prefs) {
   const wavesExcellent = numberInput(prefs.waves.excellentMaxFt, { step: 0.5 });
   const wavesAcceptable = numberInput(prefs.waves.acceptableMaxFt, { step: 0.5 });
   const wavesMarginal = numberInput(prefs.waves.marginalMaxFt, { step: 0.5 });
-  const wavesPeriod = numberInput(prefs.waves.minPeriodS, { step: 1 });
-  const wavesProtMax = numberInput(prefs.waves.protectedMaxFt, { step: 0.5 });
-  keepNested([wavesExcellent, wavesAcceptable, wavesMarginal, wavesProtMax]);
+  const wavesRatio = numberInput(prefs.waves.periodRatio, { step: 0.25 });
+  keepNested([wavesExcellent, wavesAcceptable, wavesMarginal]);
   waves.appendChild(field("Track waves at this location", wavesEnabled));
   const wavesRow = el("div", "field-row");
   wavesRow.appendChild(field("Excellent up to (ft)", wavesExcellent));
   wavesRow.appendChild(field("Acceptable up to (ft)", wavesAcceptable));
   wavesRow.appendChild(field("Marginal up to (ft)", wavesMarginal));
-  wavesRow.appendChild(field("Min period for excellent (s)", wavesPeriod));
+  wavesRow.appendChild(field("Period ratio (s per ft of swell)", wavesRatio));
   waves.appendChild(wavesRow);
-  const wavesWheel = directionWheel(prefs.waves.protectedSectors);
-  waves.appendChild(wavesWheel);
-  waves.appendChild(field("Marginal up to, from protected directions (ft)", wavesProtMax));
   frag.appendChild(waves);
 
   function read() {
@@ -236,9 +232,7 @@ export function buildPrefsForm(prefs) {
         excellentMaxFt: Number(wavesExcellent.value),
         acceptableMaxFt: Number(wavesAcceptable.value),
         marginalMaxFt: Number(wavesMarginal.value),
-        minPeriodS: Number(wavesPeriod.value),
-        protectedSectors: wavesWheel.getSelected(),
-        protectedMaxFt: Number(wavesProtMax.value),
+        periodRatio: Number(wavesRatio.value),
       },
     };
   }


### PR DESCRIPTION
Reworks the wave metric around a rule of thumb from an ocean kayak-fishing video: swell lies down when its period in seconds is at least twice its height in feet. Also fixes wind defaults that were silently shadowed, and tightens the wind tiers after a real turn-back day.

## What changed

**Wind defaults were being shadowed.** The last save from `/edit.html` stamped every location with a full copy of the old `1/2/3` Beaufort thresholds, so tightening the site defaults to `0/1/2` had no effect anywhere. Removed the redundant per-location wind blocks so the defaults (excellent B0, acceptable B1, marginal B2) actually apply. This matches Kyle turning back in Beaufort 3 conditions.

**Swell steepness rule replaces the fixed period floor.** A fixed 8-second minimum got steepness wrong: 8 seconds rides fine under a 2 ft swell and genuinely rough under a 4 ft one. The wave metric now demotes an hour one tier when the swell period is under `periodRatio` times the swell height (2x by default), and caps the hour at marginal when it misses badly (under 3/4 of the ratio), regardless of height. The check reads the swell component's own height and period, newly fetched as `swell_wave_period`, because the blended `wave_period` mixes in short wind chop and understates how the swell rides. Total wave height still drives the height tiers, so a small swell plus heavy chop is still a no-go.

**Wave direction shielding removed.** Terrain shielding from swell is about whether you can launch and land, not about tolerating bigger water once you are out, and the model's total height at a sheltered point already reflects whatever shadowing it resolves. Dropped `protectedSectors`/`protectedMaxFt` from the wave rule, the prefs form, and config.json (Avila, San Simeon, Spooner's Cove). Wind keeps its protected-direction wheel. Stored prefs migrate by dropping the dead keys.

## Reviewer notes

- Avila, San Simeon, and Spooner's Cove are now judged on raw total wave height and will red out more often than before.
- Deploy stamp and `APP_VERSION` bumped together to 9.
- The "steep swell" annotation lives only in the metric detail data for now; UI tooltips were removed in an earlier change, so it is not yet surfaced.
- Verified against live Open-Meteo data in local preview: Avila's 5.2 ft hours show red wave dots where the old protected-sector rule allowed up to 6 ft, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)