### PR TITLE
Fix Baywood Labs URL in site footer

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -124,7 +124,7 @@ async function showHome() {
   me.target = "_blank";
   me.rel = "noopener";
   const lab = el("a", null, "Baywood Labs");
-  lab.href = "https://baywoodlabs.com";
+  lab.href = "https://www.baywood-labs.com";
   lab.target = "_blank";
   lab.rel = "noopener";
   credit.append(


### PR DESCRIPTION
## Summary
- Corrected the Baywood Labs footer link from `https://baywoodlabs.com` to `https://www.baywood-labs.com` in `public/js/app.js`

## Test plan
- [x] Visual inspection of the changed line


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnzQZmKWHULk8PX6oo3KXH)_